### PR TITLE
Fix: Config reading debug log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "baldr"
 version = "0.2.0"
 edition = "2021"
+rust-version = "1.81"
 authors = [
     "Gábor Krisztián Girhiny <gk.project72@gmail.com>",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub struct Args {
 
 fn read_one_config(var: &str, cfg: ConfigBuilder<DefaultState>) -> ConfigBuilder<DefaultState> {
     if let Ok(x) = env::var(var) {
-        log::debug!("Config found in {var}.");
+        log::debug!("Looking for config in {var}.");
 
         let config_path = Path::new(&x).join("baldr");
 


### PR DESCRIPTION
The logs indicating the existence of the environment variable, not whether the config file has been successfully read.

Minimal Rust version set to 1.81.